### PR TITLE
fix: link to mdn content page

### DIFF
--- a/src/pages/compare/diff-review.tsx
+++ b/src/pages/compare/diff-review.tsx
@@ -96,7 +96,7 @@ function SourceEntryProperties({ entry, path }: { entry: Entry | null | undefine
                     </li>
                     <li>
                         <b>Link to File</b>:
-                        <a href={`https://github.com/PassionPenguin/content/blob/main/files/en-us/${path}/index.md`}>
+                        <a href={`https://github.com/mdn/content/blob/main/files/en-us/${path}/index.md`}>
                             Click HERE!
                         </a>
                     </li>


### PR DESCRIPTION
fix the link to mdn content page, as the original link to your repo may not always point to the latest version.